### PR TITLE
[Server] Can't build without 'mio' feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ path = "./src/pandora.rs"
 [dependencies]
 crossterm = "0.27.0"
 getrandom = "0.2.10"
-mio = "0.8.10"
+mio = { version = "0.8.10", features = ["os-poll", "net"] }


### PR DESCRIPTION
The server can't be compiled and requires 'os-poll' and 'net' feature flags for 'mio' crate. It's even mentioned for the example in its README file.